### PR TITLE
Add unit tests for parser utilities

### DIFF
--- a/parser/content_test.go
+++ b/parser/content_test.go
@@ -1,0 +1,28 @@
+package parser
+
+import "testing"
+
+func TestNormalizeHTML(t *testing.T) {
+	html := "<p>line1</p>\r\n<p>line2</p>\n\n<p>line3</p>"
+	got := normalizeHTML(html)
+	want := "<p>line1</p>\n<p>line2</p>\n<p>line3</p>"
+	if got != want {
+		t.Errorf("normalizeHTML got %q want %q", got, want)
+	}
+}
+
+func TestIsValidContent(t *testing.T) {
+	long := make([]byte, 100)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if !isValidContent(string(long)) {
+		t.Error("expected valid content")
+	}
+	if isValidContent("") {
+		t.Error("empty should be invalid")
+	}
+	if isValidContent("short") {
+		t.Error("short text should be invalid")
+	}
+}

--- a/parser/image_test.go
+++ b/parser/image_test.go
@@ -1,0 +1,38 @@
+package parser
+
+import "testing"
+
+func TestNormalizeImageURL(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"data:image/png;base64,xyz", ""},
+		{"http://example.com/img.jpg", "http://example.com/img.jpg"},
+		{"https://stat.ameblo.jp/foo_s.jpg", "https://stat.ameblo.jp/foo.jpg"},
+		{":bad url", ""},
+	}
+	for _, c := range cases {
+		got := normalizeImageURL(c.in)
+		if got != c.want {
+			t.Errorf("normalizeImageURL(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestGetFirstImage(t *testing.T) {
+	html := `<meta property='og:image' content='http://ex.com/og.jpg'>` +
+		`<img src='http://ex.com/a.jpg'><img src='http://ex.com/b.jpg'>`
+	p := &HTMLParser{}
+	first := p.GetFirstImage(html)
+	if first != "http://ex.com/og.jpg" {
+		t.Errorf("first image=%q", first)
+	}
+
+	html2 := `<img src='a.jpg'><img src='b.jpg'>`
+	if p.GetFirstImage(html2) != "a.jpg" {
+		t.Errorf("GetFirstImage normal failed")
+	}
+
+	if p.GetFirstImage("") != "" {
+		t.Errorf("expected empty for no image")
+	}
+}

--- a/parser/tag_test.go
+++ b/parser/tag_test.go
@@ -1,0 +1,55 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestCleanTag(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"  #Go \nブログ", "Go"},
+		{"心理カウンセラー・中井亜紀『成長の記録』タグ", "タグ"},
+		{"multi   space", "multi space"},
+	}
+	for _, c := range cases {
+		got := cleanTag(c.in)
+		if got != c.want {
+			t.Errorf("cleanTag(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExtractTags(t *testing.T) {
+	html := `
+<meta name='keywords' content='kw1, kw2'>
+<div class='skin-tagLabel'>TagA</div>
+<script>var ld_blog_vars={tags:['TagB','TagC']};</script>
+<div class='tags'><a>TagD</a></div>
+<div class='tag'>TagE</div>
+`
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("doc error: %v", err)
+	}
+	tags, err := extractTags(doc)
+	if err != nil {
+		t.Fatalf("extractTags error: %v", err)
+	}
+	expected := []string{"TagA", "TagB", "TagC", "kw1", "kw2", "TagD", "TagE"}
+	if len(tags) != len(expected) {
+		t.Fatalf("got %d tags want %d", len(tags), len(expected))
+	}
+	for _, e := range expected {
+		if !containsString(tags, e) {
+			t.Errorf("expected tag %q", e)
+		}
+	}
+}
+
+func TestExtractTagsNil(t *testing.T) {
+	if _, err := extractTags(nil); err == nil {
+		t.Error("expected error with nil document")
+	}
+}

--- a/parser/title_test.go
+++ b/parser/title_test.go
@@ -1,0 +1,73 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestCleanTitle(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"  サンプル\nタイトル  | 心理カウンセラー・中井亜紀『成長の記録』", "サンプル タイトル"},
+		{"\"quoted\"", "\\\"quoted\\\""},
+		{" multiple   spaces ", "multiple spaces"},
+	}
+	for _, c := range cases {
+		got := cleanTitle(c.in)
+		if got != c.want {
+			t.Errorf("cleanTitle(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsValidTitle(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"Valid Title", true},
+		{"", false},
+		{"<b>bad</b>", false},
+		{"bad\x01", false},
+	}
+	for _, c := range cases {
+		got := isValidTitle(c.in)
+		if got != c.want {
+			t.Errorf("isValidTitle(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExtractTitle(t *testing.T) {
+	cases := []struct{ html, want string }{
+		{`<script>var ld_blog_vars={articles:[{title:'Script Title'}]};</script>` +
+			`<meta property='og:title' content='OG Title'>` +
+			`<h1>H1 Title</h1>` +
+			`<title>Doc Title</title>` +
+			`<meta name='title' content='Meta Title'>`, "Script Title"},
+		{`<meta property='og:title' content='OG Title'><h1>H1 Title</h1>`, "OG Title"},
+		{`<h1>H1 Title</h1><title>Doc Title</title>`, "H1 Title"},
+		{`<title>Doc Title</title>`, "Doc Title"},
+		{`<meta name='title' content='Meta Title'>`, "Meta Title"},
+	}
+	for i, c := range cases {
+		doc, err := goquery.NewDocumentFromReader(strings.NewReader(c.html))
+		if err != nil {
+			t.Fatalf("case %d: %v", i, err)
+		}
+		got, err := extractTitle(doc)
+		if err != nil {
+			t.Fatalf("case %d: extractTitle error: %v", i, err)
+		}
+		if got != c.want {
+			t.Errorf("case %d: extractTitle()=%q want %q", i, got, c.want)
+		}
+	}
+
+	// error when nothing found
+	doc, _ := goquery.NewDocumentFromReader(strings.NewReader(`<div></div>`))
+	if _, err := extractTitle(doc); err == nil {
+		t.Error("expected error when title not found")
+	}
+}

--- a/pkg/models/blog_test.go
+++ b/pkg/models/blog_test.go
@@ -1,0 +1,26 @@
+package models
+
+import "testing"
+
+func TestSetSlug(t *testing.T) {
+	cases := []struct{ title, want string }{
+		{"Hello World!", "hello-world"},
+		{"日本語タイトル", ""},
+		{"Mixed 123 Title", "mixed-123-title"},
+		{"  spaces  here  ", "spaces-here"},
+	}
+	for _, c := range cases {
+		b := &BlogPost{Title: c.title}
+		b.SetSlug()
+		if b.Slug != c.want {
+			t.Errorf("SetSlug(%q)=%q want %q", c.title, b.Slug, c.want)
+		}
+	}
+}
+
+func TestRemoveNonASCII(t *testing.T) {
+	got := removeNonASCII("aあb1")
+	if got != "ab1" {
+		t.Errorf("removeNonASCII unexpected %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for title parsing functions
- add tests for tag extraction
- add tests for image URL handling
- add tests for content helpers
- add tests for BlogPost slug generation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68403740f0ec833184384ccd4f9b9e04